### PR TITLE
Watch for configuration changes

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # Install wireguard packges
-RUN apk --no-cache add wireguard-tools iptables ip6tables
+RUN apk --no-cache add wireguard-tools iptables ip6tables inotify-tools
 
 # Add main work dir to PATH
 WORKDIR /scripts

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -5,7 +5,7 @@ RUN echo "deb http://deb.debian.org/debian/ buster-backports main" > /etc/apt/so
 
 # Install wireguard packges
 RUN apt-get update && \
- apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv && \
+ apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv inotify-tools && \
  apt-get clean
 
 # Add main work dir to PATH

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -6,7 +6,7 @@ RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.li
 
 # Install wireguard packges
 RUN apt-get update && \
- apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv && \
+ apt-get install -y --no-install-recommends wireguard-tools iptables nano net-tools procps openresolv inotify-tools && \
  apt-get clean
 
 # Add main work dir to PATH

--- a/run
+++ b/run
@@ -9,10 +9,20 @@ if [ -z $interfaces ]; then
     exit 1
 fi
 
-for interface in $interfaces; do
-    echo "$(date): Starting Wireguard $interface"
-    wg-quick up $interface
-done
+start_interfaces() {
+    for interface in $interfaces; do
+        echo "$(date): Starting Wireguard $interface"
+        wg-quick up $interface
+    done
+}
+
+stop_interfaces() {
+    for interface in $interfaces; do
+        wg-quick down $interface
+    done
+}
+
+start_interfaces
 
 # Add masquerade rule for NAT'ing VPN traffic bound for the Internet
 
@@ -24,9 +34,7 @@ fi
 # Handle shutdown behavior
 finish () {
     echo "$(date): Shutting down Wireguard"
-    for interface in $interfaces; do
-        wg-quick down $interface
-    done
+    stop_interfaces
     if [ $IPTABLES_MASQ -eq 1 ]; then
         iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
     fi
@@ -36,5 +44,7 @@ finish () {
 
 trap finish TERM INT QUIT
 
-sleep infinity &
-wait $!
+while inotifywait -e modify -e create /etc/wireguard; do
+    stop_interfaces
+    start_interfaces
+done


### PR DESCRIPTION
Watching for changes and reloading wireguard when one is detected is
very useful if an external GUI is used. Usually the GUIs work by
updating wg0.conf or another interface file, but they don't
automatically restart wireguard. This allows easily linking a GUI with
wireguard.